### PR TITLE
adds use-ip-addresses feature-updates sha1 for bpm

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -16,7 +16,7 @@ set -eu
 validate_features broker metrics-emitter no-rmq-tls no-mgmt-tls no-broker-tls \
                   external-rmq-lb route-registrar nats-tls stomp \
                   provided-rmq-cert provided-mgmt-cert provided-broker-cert \
-                  prometheus no-prometheus-tls
+                  prometheus no-prometheus-tls use-ip-addresses
 
 declare -a manifests
 manifests+=( manifests/base.yml
@@ -126,6 +126,12 @@ if want_feature "no-mgmt-tls" ; then
   if want_feature "provided-mgmt-cert" ; then
     bail "" "Cannot have no-mgmt-tls and provided-mgmt-cert features"
   fi
+fi
+
+if want_feature "use-ip-addresses" ; then
+  manifests+=(
+    manifests/addons/use-ip-addresses.yml
+  )
 fi
 
 if want_feature "external-rmq-lb" ; then

--- a/manifests/addons/use-ip-addresses.yml
+++ b/manifests/addons/use-ip-addresses.yml
@@ -1,0 +1,6 @@
+---
+- type: replace
+  path: /instance_groups/name=rmq-server/jobs/name=rabbitmq-server/consumes?
+  value:
+    rabbitmq-server:
+      ip_addresses: true

--- a/manifests/releases/bpm.yml
+++ b/manifests/releases/bpm.yml
@@ -4,4 +4,4 @@
     name: bpm
     version: 1.1.16
     url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
-    sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+    sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e

--- a/spec/results/base-allparams.yml
+++ b/spec/results/base-allparams.yml
@@ -215,7 +215,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/base.yml
+++ b/spec/results/base.yml
@@ -76,7 +76,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/broker.yml
+++ b/spec/results/broker.yml
@@ -215,7 +215,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/external-rmq-lb.yml
+++ b/spec/results/external-rmq-lb.yml
@@ -198,7 +198,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/metrics-emitter.yml
+++ b/spec/results/metrics-emitter.yml
@@ -251,7 +251,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/nats-tls.yml
+++ b/spec/results/nats-tls.yml
@@ -261,7 +261,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/no-tls.yml
+++ b/spec/results/no-tls.yml
@@ -150,7 +150,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/route-registrar.yml
+++ b/spec/results/route-registrar.yml
@@ -247,7 +247,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy

--- a/spec/results/stomp.yml
+++ b/spec/results/stomp.yml
@@ -80,7 +80,7 @@ releases:
   url: https://cf-rabbitmq-genesis-releases.s3.amazonaws.com/cf-rabbitmq-419.0.0.tgz
   version: 419.0.0
 - name: bpm
-  sha1: a4b8a7601e8450a66a97a789ce7574248d188c41
+  sha1: 492f181f4efa08c5f0b45d22cbe54f0a20edf99e
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.16
   version: 1.1.16
 - name: haproxy


### PR DESCRIPTION
Features

* Add support for bosh [v2.2.6](]https://github.com/genesis-community/bosh-genesis-kit/releases/tag/v2.2.6) in form of `use-ip-addresses` feature

Using the latest bosh genesis kit [v2.2.6](]https://github.com/genesis-community/bosh-genesis-kit/releases/tag/v2.2.6) produces a failure on the pre-start script of rabbitmq-server:

 ```
                       L Error: Action Failed get_task: Task 537da460-4cae-476b-6a21-143880115d5f result: 1 of 3 pre-start scripts failed. Failed Jobs: rabbitmq-server. Successful Jobs: bosh-dns, user_add.
```

```
=ERROR REPORT==== 13-Sep-2022::15:33:15.447515 ===
inet_config: parse error in /var/vcap/store/rabbitmq/erl_inetrc
```

this is due `erl_inetrc` population with hostnames instead of the ips:

```
{host, {3f231617-6718-44c3-9852-7abfaf103a49,rmq-server,rabbitmq,snw-itsouvalas-lab-rabbitmq,bosh}, ["24e5c8ff5946a1ae7dd9af89850701fa"]}.
{host, {11bf1b97-05f3-4968-b494-f2e5083cc0dc,rmq-server,rabbitmq,snw-itsouvalas-lab-rabbitmq,bosh}, ["293ce376940436feb38a922ef8d345e3"]}.
{host, {c7456f78-6c0e-4e4c-9966-0c835f9f4bf5,rmq-server,rabbitmq,snw-itsouvalas-lab-rabbitmq,bosh}, ["54a862725983654db1c81d63a50b2b16"]}.
{lookup, [file, native]}.
```

This is due to the recent enablement on [v2.2.6](]https://github.com/genesis-community/bosh-genesis-kit/releases/tag/v2.2.6)  of using [dns-addresses](https://github.com/cloudfoundry/bosh-deployment/commit/6d6f24f8f7eddf51267c41b227f4c75c17bb9e14).

To address this `use-ip-addresses` merges `manifests/addons/use-ip-addresses.yml` which sets `ip_addresses: true` which leads to the expected format:

```
{host, {10,128,184,50}, ["4afd6889d1e2f37135abbc45b2bedcf4"]}.
{host, {10,128,184,51}, ["214dede44c45c4424dea454c3ca00ad5"]}.
{host, {10,128,184,52}, ["61b9cf2e8ed7665036a2fdc20da1a9ed"]}.
{lookup, [file, native]}.
```

Bugs

* fix `sha1` for `bpm` as reported by [bpm-release](https://bosh.io/releases/github.com/cloudfoundry/bpm-release?version=1.1.16)